### PR TITLE
Remove AES encryption of Google credentials

### DIFF
--- a/playmaker/server.py
+++ b/playmaker/server.py
@@ -38,7 +38,7 @@ def createServer(service):
         @run_on_executor
         def login(self):
             data = tornado.escape.json_decode(self.request.body)
-            return service.login(data['cyphertext'], data['password'])
+            return service.login(data['email'], data['password'])
 
         @run_on_executor
         def download(self):

--- a/playmaker/service.py
+++ b/playmaker/service.py
@@ -1,7 +1,6 @@
 from gpapi.googleplay import GooglePlayAPI, LoginError, RequestError
 from pyaxmlparser import APK
 from subprocess import Popen, PIPE
-from Crypto.Cipher import AES
 
 import base64
 import os
@@ -97,21 +96,14 @@ class Play(object):
         return {'status': 'SUCCESS',
                 'message': sorted(self.currentSet, key=lambda k: k['title'])}
 
-    def login(self, ciphertext=None, hashToB64=None):
+    def login(self, email=None, password=None):
         def unpad(s):
             return s[:-ord(s[len(s)-1:])]
 
         try:
-            if ciphertext is not None and hashToB64 is not None:
-                cipher = base64.b64decode(ciphertext)
-                passwd = base64.b64decode(hashToB64)
-                # first 16 bytes corresponds to the init vector
-                iv = cipher[0:16]
-                cipher = cipher[16:]
-                aes = AES.new(passwd, AES.MODE_CBC, iv)
-                result = unpad(aes.decrypt(cipher)).split(b'\x00')
-                self._email = result[0].decode('utf-8')
-                self._passwd = result[1].decode('utf-8')
+            if email is not None and password is not None:
+                self._email = base64.b64decode(email).decode('utf-8')
+                self._passwd = base64.b64decode(password).decode('utf-8')
                 self.service.login(self._email,
                                    self._passwd,
                                    None, None)

--- a/playmaker/static/app.module.js
+++ b/playmaker/static/app.module.js
@@ -280,19 +280,11 @@ app.component('loginView', {
 
       ctrl.loggingIn = true;
 
-      var plaintext = user.email + '\x00' + user.password;
-      var plaintextHash = CryptoJS.SHA256(plaintext);
-      //using sha256(message) as key
-      var iv = CryptoJS.lib.WordArray.random(16);
-      var encrypted = CryptoJS.AES.encrypt(plaintext, plaintextHash, {
-        iv: iv,
-        mode: CryptoJS.mode.CBC
-      });
-      iv.concat(encrypted.ciphertext)
-      var ciphertext = CryptoJS.enc.Base64.stringify(iv);
-      var hashToB64 = CryptoJS.enc.Base64.stringify(plaintextHash);
-
-      api.login(ciphertext, hashToB64, function(data) {
+      var email = CryptoJS.enc.Utf8.parse(user.email);
+      var passwd = CryptoJS.enc.Utf8.parse(user.password);
+      var emailB64 = CryptoJS.enc.Base64.stringify(email);
+      var passwdB64 = CryptoJS.enc.Base64.stringify(passwd);
+      api.login(emailB64, passwdB64, function(data) {
         if (data.status === 'ERROR') {
           global.addAlert('danger', data.message);
           ctrl.loggingIn = false;

--- a/playmaker/static/app.service.js
+++ b/playmaker/static/app.service.js
@@ -120,12 +120,12 @@ angular.module('playmaker').service('api', ['$http', '$location', 'global', func
     });
   };
 
-  this.login = function(cyphertext, password, callback) {
+  this.login = function(email, password, callback) {
     $http({
       method: 'POST',
       url: '/api/login',
       data: JSON.stringify({
-        cyphertext: cyphertext,
+        email: email,
         password: password
       })
     }).then(function success(response) {


### PR DESCRIPTION
 Plaintext credentials were needed server-side to obtain the Google api cookies, therefore a mock encryption was employed. Now data are sent in plaintext, in favor of a future HTTPS enforcement.