### PR TITLE
Fix configparse exception with gpapi 0.4.3

### DIFF
--- a/playmaker/service.py
+++ b/playmaker/service.py
@@ -75,7 +75,7 @@ class Play(object):
         timezone = os.environ.get('LANG_TIMEZONE')
         if timezone is None:
             timezone = 'Europe/Berlin'
-        self.service = GooglePlayAPI(locale, timezone, self.debug)
+        self.service = GooglePlayAPI(locale, timezone)
 
     def fdroid_init(self):
         found = False


### PR DESCRIPTION
With gpapi 0.4.3 the arguments of the GooglePlayAPI class constructor changed. The parameter `debug` was removed, making the third positional argument to become `device_codename` instead. Following exception was thrown: `configparser.NoSectionError: No section: True`.