### PR TITLE
Close menu automatically again after select

### DIFF
--- a/playmaker/index.html
+++ b/playmaker/index.html
@@ -75,6 +75,7 @@
   <script src="/static/js/angular-animate.min.js"></script>
   <script src="/static/js/angular-touch.min.js"></script>
   <script src="/static/js/ui-bootstrap.min.js"></script>
+  <script src="/static/js/additional.js"></script>
   <!-- crypto library -->
 
   <script src="/static/js/crypto-js.js"></script>

--- a/playmaker/static/js/additional.js
+++ b/playmaker/static/js/additional.js
@@ -1,0 +1,5 @@
+$(document).on('click', '.navbar-collapse.in', function(e) {
+    if($(e.target).is('a')) {
+        $(this).collapse('hide');
+    }
+});


### PR DESCRIPTION
When in mobile view, the menu don't close automatically after selecting a menu item. It needs to be closed again in order to see and use the underlying elements. This is a bit confusing and inconvenient.
The added JS closes the menu on a click again.