### PR TITLE
Implement token authentication

### DIFF
--- a/playmaker/service.py
+++ b/playmaker/service.py
@@ -54,6 +54,8 @@ class Play(object):
         self.loggedIn = False
         self._email = None
         self._passwd = None
+        self._gsfId = None
+        self._token = None
         self._last_fdroid_update = None
 
         # configuring download folder
@@ -170,16 +172,26 @@ class Play(object):
         self._email = email
         self._passwd = password
 
+    def set_token_credentials(self, gsfId, token):
+        self._gsfId = int(gsfId, 16)
+        self._token = token
+
+    def has_credentials(self):
+        passwd_credentials = self._email is not None and self._passwd is not None
+        token_credentials = self._gsfId is not None and self._token is not None
+        return passwd_credentials or token_credentials
+
     def login(self):
         if self.loggedIn:
             return {'status': 'SUCCESS', 'message': 'OK'}
 
         try:
-            if self._email is None or self._passwd is None:
-                raise LoginError("either username or password is null")
+            if not self.has_credentials():
+                raise LoginError("missing credentials")
             self.service.login(self._email,
                                self._passwd,
-                               None, None)
+                               self._gsfId,
+                               self._token)
             self.loggedIn = True
             return {'status': 'SUCCESS', 'message': 'OK'}
         except LoginError as e:

--- a/pm-server
+++ b/pm-server
@@ -48,14 +48,15 @@ if __name__ == '__main__':
 
     # credentials setup
     auth_file_parser = configparser.ConfigParser()
-    email = None
-    password = None
-    if len(auth_file_parser.read('credentials.conf')) != 0:
-        email = auth_file_parser['google']['email']
-        password = auth_file_parser['google']['password']
+    auth_file_parser.read('credentials.conf')
+    if 'google' in auth_file_parser:
+        google_section = auth_file_parser['google']
+        if 'email' in google_section and 'password' in google_section:
+            service.set_credentials(google_section['email'], google_section['password'])
+        elif 'gsfId' in google_section and 'token' in google_section:
+            service.set_token_credentials(google_section['gsfId'], google_section['token'])
 
-    if email is not None and password is not None:
-        service.set_credentials(email, password)
+    if service.has_credentials():
         service.login()
         service.update_state()
 


### PR DESCRIPTION
Sometimes user and password is not available and you want to authenticate directly via tokens.
For example, if you want to re-use shared accounts from other apps (e.g. [APKUpdater](https://github.com/rumboalla/apkupdater/blob/master/app/src/main/java/com/apkupdater/util/GooglePlayUtil.java)).