### PR TITLE
First steps to adjust for GooglePlay API v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ RUN wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip \
 RUN mkdir /opt/android-sdk-linux
 ENV ANDROID_HOME=/opt/android-sdk-linux
 ENV PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools
-RUN echo 'y' | tools/bin/sdkmanager --sdk_root=/opt/android-sdk-linux --verbose "platforms;android-26" \
-    && tools/bin/sdkmanager --sdk_root=/opt/android-sdk-linux --verbose "build-tools;26.0.1" \
-    && rm -rf tools
+RUN echo 'y' | tools/bin/sdkmanager --sdk_root=/opt/android-sdk-linux --verbose --install "platforms;android-28" "build-tools;28.0.3"
+#RUN echo 'y' | tools/bin/sdkmanager --sdk_root=/opt/android-sdk-linux --verbose "build-tools;29.0.2"
+RUN echo 'y' | rm -rf tools
 
 RUN mkdir -p /data/fdroid/repo && \
     mkdir -p /opt/playmaker
@@ -39,6 +39,7 @@ COPY README.md setup.py pm-server /opt/playmaker/
 ADD playmaker /opt/playmaker/playmaker
 
 WORKDIR /opt/playmaker
+RUN pip3 install --upgrade pip
 RUN pip3 install . && \
     cd /opt && rm -rf playmaker && \
     sed -i 's/\"sdk_version\"/#\"sdk_version\"/g' /usr/local/lib/python3.7/site-packages/gpapi/config.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,34 +18,44 @@ RUN apt-get update && \
     zlib1g-dev \
     less \
     mc \
-    nano
+    nano \
+    android-sdk-platform-tools \
+    android-sdk-build-tools && \
+    rm -rf /var/lib/apt/lists
 
-RUN wget https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip \
-    && echo "F10F9D5BCA53CC27E2D210BE2CBC7C0F1EE906AD9B868748D74D62E10F2C8275 commandlinetools-linux-6200805_latest.zip" | sha256sum -c \
-    && unzip commandlinetools-linux-6200805_latest.zip \
-    && rm commandlinetools-linux-6200805_latest.zip
+#RUN wget https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip \
+#    && echo "F10F9D5BCA53CC27E2D210BE2CBC7C0F1EE906AD9B868748D74D62E10F2C8275 commandlinetools-linux-6200805_latest.zip" | sha256sum -c \
+#    && unzip commandlinetools-linux-6200805_latest.zip \
+#    && rm commandlinetools-linux-6200805_latest.zip
 
-RUN mkdir /opt/android-sdk-linux \
-    && mv tools /opt/android-sdk-linux/tools
+#RUN mkdir /opt/android-sdk-linux \
+#    && mv tools /opt/android-sdk-linux/tools
 
-ENV ANDROID_HOME=/opt/android-sdk-linux
-ENV PATH=$PATH:$ANDROID_HOME/tools
+#ENV ANDROID_HOME=/opt/android-sdk-linux
+#ENV PATH=$PATH:$ANDROID_HOME/tools
 
-RUN echo 'y' | /opt/android-sdk-linux/tools/bin/sdkmanager --sdk_root=/opt/android-sdk-linux --verbose --install "platforms;android-28" "build-tools;28.0.3"
+#RUN echo 'y' | /opt/android-sdk-linux/tools/bin/sdkmanager --sdk_root=/opt/android-sdk-linux --verbose --install "platforms;android-28" "build-tools;28.0.3"
 
-RUN echo 'y' | rm -rf tools
+#RUN echo 'y' | rm -rf tools
 
 RUN mkdir -p /data/fdroid/repo && \
     mkdir -p /opt/playmaker
 
 COPY README.md setup.py pm-server /opt/playmaker/
-ADD playmaker /opt/playmaker/playmaker
+COPY playmaker /opt/playmaker/playmaker
+RUN rm -rf /usr/bin/apksigner
+COPY apksigner /usr/bin/apksigner
 
 WORKDIR /opt/playmaker
 RUN pip3 install . && \
     cd /opt && rm -rf playmaker
 
-RUN pip install fdroidserver
+#RUN pip3 install fdroidserver
+RUN pip3 install Cython && \
+	pip3 install fdroidserver && \
+    pip3 install . && \
+    cd /opt && rm -rf playmaker && \
+    sed -i 's/\"sdk_version\"/#\"sdk_version\"/g' /usr/local/lib/python3.8/site-packages/gpapi/config.py
 
 RUN groupadd -g 999 pmuser && \
     useradd -m -u 999 -g pmuser pmuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,38 @@
-FROM python:3-stretch
+FROM python:3-buster
 
 RUN apt-get update && \
     apt-get install -y git \
     lib32stdc++6 \
     lib32gcc1 \
     lib32z1 \
-    lib32ncurses5 \
+    lib32ncurses6 \
     libffi-dev \
     libssl-dev \
     libjpeg-dev \
     libxml2-dev \
     libxslt1-dev \
-    openjdk-8-jdk-headless \
+    openjdk-11-jdk-headless \
     virtualenv \
     wget \
     unzip \
-    fdroidserver \
     zlib1g-dev \
     less \
+    mc \
     nano
 
-RUN wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip \
-    && echo "92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9 sdk-tools-linux-4333796.zip" | sha256sum -c \
-    && unzip sdk-tools-linux-4333796.zip \
-    && rm sdk-tools-linux-4333796.zip
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip \
+    && echo "F10F9D5BCA53CC27E2D210BE2CBC7C0F1EE906AD9B868748D74D62E10F2C8275 commandlinetools-linux-6200805_latest.zip" | sha256sum -c \
+    && unzip commandlinetools-linux-6200805_latest.zip \
+    && rm commandlinetools-linux-6200805_latest.zip
 
-RUN mkdir /opt/android-sdk-linux
+RUN mkdir /opt/android-sdk-linux \
+    && mv tools /opt/android-sdk-linux/tools
+
 ENV ANDROID_HOME=/opt/android-sdk-linux
-ENV PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools
-RUN echo 'y' | tools/bin/sdkmanager --sdk_root=/opt/android-sdk-linux --verbose --install "platforms;android-28" "build-tools;28.0.3"
-#RUN echo 'y' | tools/bin/sdkmanager --sdk_root=/opt/android-sdk-linux --verbose "build-tools;29.0.2"
+ENV PATH=$PATH:$ANDROID_HOME/tools
+
+RUN echo 'y' | /opt/android-sdk-linux/tools/bin/sdkmanager --sdk_root=/opt/android-sdk-linux --verbose --install "platforms;android-28" "build-tools;28.0.3"
+
 RUN echo 'y' | rm -rf tools
 
 RUN mkdir -p /data/fdroid/repo && \
@@ -39,10 +42,10 @@ COPY README.md setup.py pm-server /opt/playmaker/
 ADD playmaker /opt/playmaker/playmaker
 
 WORKDIR /opt/playmaker
-RUN pip3 install --upgrade pip
 RUN pip3 install . && \
-    cd /opt && rm -rf playmaker && \
-    sed -i 's/\"sdk_version\"/#\"sdk_version\"/g' /usr/local/lib/python3.7/site-packages/gpapi/config.py
+    cd /opt && rm -rf playmaker
+
+RUN pip install fdroidserver
 
 RUN groupadd -g 999 pmuser && \
     useradd -m -u 999 -g pmuser pmuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,6 @@ RUN mkdir -p /data/fdroid/repo && \
 
 COPY README.md setup.py pm-server /opt/playmaker/
 COPY playmaker /opt/playmaker/playmaker
-RUN rm -rf /usr/bin/apksigner
-COPY apksigner /usr/bin/apksigner
 
 WORKDIR /opt/playmaker
 RUN pip3 install . && \

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ docker run -d --name playmaker \
     -v /srv/fdroid:/data/fdroid \
     -e HTTPS_CERTFILE="/srv/https.crt" \
     -e HTTPS_KEYFILE="/srv/https.key" \
-    -e LANG_LOCALE="it_IT" \
-    -e LANG_TIMEZONE="Europe/Rome" \
+    -e LANG_LOCALE="de_DE" \
+    -e LANG_TIMEZONE="Europe/Berlin" \
     -e DEVICE_CODE="hammerhead" \
-    nomore201/playmaker
+    fellek/playmaker:fellek
 ```
 
 If you want to run it in a virtualenv rather than using docker, remember that you need to install fdroidserver,

--- a/playmaker/service.py
+++ b/playmaker/service.py
@@ -313,12 +313,12 @@ class Play(object):
                 print('Package %s does not exits' % docid)
                 unavail.append(docid)
                 continue
-            print('Downloading %s' % docid)
+            print('Downloading %s' % docid % ' ' % filename)
             try:
                 if details.get('offer')[0].get('micros') == 0:
-                    data_gen = self.service.download(docid, details.appDetails.file['versionCode'])
+                    data_gen = self.service.download(docid, details['versionCode'])
                 else:
-                    data_gen = self.service.delivery(docid, details.appDetails.file['versionCode'])
+                    data_gen = self.service.delivery(docid, details['versionCode'])
                 data_gen = data_gen.get('file').get('data')
             except IndexError as exc:
                 print(exc)
@@ -357,14 +357,15 @@ class Play(object):
             toUpdate = []
             for app in self.currentSet:
                 details = self.details(app.get('docid'))
+                appDetails = details.get('appDetails')
                 if details is None:
                     print('%s not available in Play Store' % app['docid'])
                     continue
                 details['filename'] = app.get('filename')
                 if self.debug:
                     print('Checking %s' % app['docid'])
-                    print('%d == %d ?' % (app['versionCode'], details.appDetails.file['versionCode']))
-                if app['versionCode'] != details.appDetails.file['versionCode']:
+                    print('%d == %d ?' % (app['versionCode'], appDetails['versionCode']))
+                if app['versionCode'] != appDetails['versionCode']:
                     toUpdate.append(details)
         return {'status': 'SUCCESS',
                 'message': toUpdate}

--- a/playmaker/service.py
+++ b/playmaker/service.py
@@ -316,9 +316,9 @@ class Play(object):
             print('Downloading %s' % docid)
             try:
                 if details.get('offer')[0].get('micros') == 0:
-                    data_gen = self.service.download(docid, details['versionCode'])
+                    data_gen = self.service.download(docid, details.appDetails.file['versionCode'])
                 else:
-                    data_gen = self.service.delivery(docid, details['versionCode'])
+                    data_gen = self.service.delivery(docid, details.appDetails.file['versionCode'])
                 data_gen = data_gen.get('file').get('data')
             except IndexError as exc:
                 print(exc)
@@ -363,8 +363,8 @@ class Play(object):
                 details['filename'] = app.get('filename')
                 if self.debug:
                     print('Checking %s' % app['docid'])
-                    print('%d == %d ?' % (app['versionCode'], details['versionCode']))
-                if app['versionCode'] != details['versionCode']:
+                    print('%d == %d ?' % (app['versionCode'], details.appDetails.file['versionCode']))
+                if app['versionCode'] != details.appDetails.file['versionCode']:
                     toUpdate.append(details)
         return {'status': 'SUCCESS',
                 'message': toUpdate}

--- a/playmaker/service.py
+++ b/playmaker/service.py
@@ -36,11 +36,11 @@ def get_details_from_apk(apk, downloadPath, service):
         except RequestError as e:
             print('Cannot fetch information for %s' % a.package)
             print('Extracting basic information from package...')
-            return {'docId': a.package,
+            return {'docid': a.package,
                     'filename': apk,
                     'versionCode': int(a.version_code),
                     'title': a.application}
-        print('Added %s to cache' % details['docId'])
+        print('Added %s to cache' % details['docid'])
     return details
 
 
@@ -245,17 +245,17 @@ class Play(object):
 
     def insert_app_into_state(self, newApp):
         found = False
-        result = list(filter(lambda x: x['docId'] == newApp['docId'],
+        result = list(filter(lambda x: x['docid'] == newApp['docid'],
                              self.currentSet))
         if len(result) > 0:
             found = True
             if self.debug:
-                print('%s is already cached, updating..' % newApp['docId'])
+                print('%s is already cached, updating..' % newApp['docid'])
                 i = self.currentSet.index(result[0])
                 self.currentSet[i] = newApp
         if not found:
             if self.debug:
-                print('Adding %s into cache..' % newApp['docId'])
+                print('Adding %s into cache..' % newApp['docid'])
             self.currentSet.append(newApp)
 
     def search(self, appName, numItems=15):
@@ -304,11 +304,11 @@ class Play(object):
         unavail = []
 
         for app in apps:
-            docid = app.get('docId')
+            docid = app.get('docid')
             details = self.details(docid)
             filename = app.get('filename')
             if filename is None:
-                filename = details.get('docId') + '.apk'
+                filename = details.get('docid') + '.apk'
             if details is None:
                 print('Package %s does not exits' % docid)
                 unavail.append(docid)
@@ -356,24 +356,24 @@ class Play(object):
         else:
             toUpdate = []
             for app in self.currentSet:
-                details = self.details(app.get('docId'))
+                details = self.details(app.get('docid'))
                 if details is None:
-                    print('%s not available in Play Store' % app['docId'])
+                    print('%s not available in Play Store' % app['docid'])
                     continue
                 details['filename'] = app.get('filename')
                 if self.debug:
-                    print('Checking %s' % app['docId'])
+                    print('Checking %s' % app['docid'])
                     print('%d == %d ?' % (app['versionCode'], details['versionCode']))
                 if app['versionCode'] != details['versionCode']:
                     toUpdate.append(details)
         return {'status': 'SUCCESS',
                 'message': toUpdate}
 
-    def remove_local_app(self, docId):
+    def remove_local_app(self, docid):
         if not self.loggedIn:
             return {'status': 'UNAUTHORIZED'}
         # get app from cache
-        app = list(filter(lambda x: x['docId'] == docId, self.currentSet))
+        app = list(filter(lambda x: x['docid'] == docid, self.currentSet))
         if len(app) < 1:
             return {'status': 'ERROR'}
         apkPath = os.path.join(self.download_path, app[0]['filename'])

--- a/playmaker/service.py
+++ b/playmaker/service.py
@@ -315,6 +315,7 @@ class Play(object):
                 print('Package %s does not exits' % docid)
                 unavail.append(docid)
                 continue
+            print('Downloading %s' % docid)
             try:
                 if details.get('offer')[0].get('micros') == 0:
                     data_gen = self.service.download(docid, appDetails['versionCode'])
@@ -358,6 +359,7 @@ class Play(object):
             toUpdate = []
             for app in self.currentSet:
                 details = self.details(app.get('docid'))
+                #print(details)
                 detailss = details.get('details')
                 appDetails = detailss.get('appDetails')
                 if details is None:

--- a/playmaker/service.py
+++ b/playmaker/service.py
@@ -306,6 +306,8 @@ class Play(object):
         for app in apps:
             docid = app.get('docid')
             details = self.details(docid)
+            detailss = details.get('details')
+            appDetails = detailss.get('appDetails')
             filename = app.get('filename')
             if filename is None:
                 filename = details.get('docid') + '.apk'
@@ -313,12 +315,11 @@ class Play(object):
                 print('Package %s does not exits' % docid)
                 unavail.append(docid)
                 continue
-            print('Downloading %s' % docid % ' ' % filename)
             try:
                 if details.get('offer')[0].get('micros') == 0:
-                    data_gen = self.service.download(docid, details['versionCode'])
+                    data_gen = self.service.download(docid, appDetails['versionCode'])
                 else:
-                    data_gen = self.service.delivery(docid, details['versionCode'])
+                    data_gen = self.service.delivery(docid, appDetails['versionCode'])
                 data_gen = data_gen.get('file').get('data')
             except IndexError as exc:
                 print(exc)
@@ -357,15 +358,16 @@ class Play(object):
             toUpdate = []
             for app in self.currentSet:
                 details = self.details(app.get('docid'))
-                appDetails = details.get('appDetails')
+                detailss = details.get('details')
+                appDetails = detailss.get('appDetails')
                 if details is None:
                     print('%s not available in Play Store' % app['docid'])
                     continue
                 details['filename'] = app.get('filename')
                 if self.debug:
                     print('Checking %s' % app['docid'])
-                    print('%d == %d ?' % (app['versionCode'], appDetails['versionCode']))
-                if app['versionCode'] != appDetails['versionCode']:
+                    print('%d == %d ?' % (app['versionCode'], details['versionCode']))
+                if app['versionCode'] != details['versionCode']:
                     toUpdate.append(details)
         return {'status': 'SUCCESS',
                 'message': toUpdate}

--- a/playmaker/service.py
+++ b/playmaker/service.py
@@ -263,7 +263,7 @@ class Play(object):
             return {'status': 'UNAUTHORIZED'}
 
         try:
-            apps = self.service.search(appName, numItems, None)
+            apps = self.service.search(appName, numItems)
         except RequestError as e:
             print(e)
             self.loggedIn = False

--- a/playmaker/service.py
+++ b/playmaker/service.py
@@ -263,7 +263,7 @@ class Play(object):
             return {'status': 'UNAUTHORIZED'}
 
         try:
-            apps = self.service.search(appName, numItems)
+            apps = self.service.search(appName)
         except RequestError as e:
             print(e)
             self.loggedIn = False

--- a/playmaker/service.py
+++ b/playmaker/service.py
@@ -306,8 +306,6 @@ class Play(object):
         for app in apps:
             docid = app.get('docid')
             details = self.details(docid)
-            detailss = details.get('details')
-            appDetails = detailss.get('appDetails')
             filename = app.get('filename')
             if filename is None:
                 filename = details.get('docid') + '.apk'
@@ -318,9 +316,9 @@ class Play(object):
             print('Downloading %s' % docid)
             try:
                 if details.get('offer')[0].get('micros') == 0:
-                    data_gen = self.service.download(docid, appDetails['versionCode'])
+                    data_gen = self.service.download(docid, details.get('details').get('appDetails')['versionCode'])
                 else:
-                    data_gen = self.service.delivery(docid, appDetails['versionCode'])
+                    data_gen = self.service.delivery(docid, details.get('details').get('appDetails')['versionCode'])
                 data_gen = data_gen.get('file').get('data')
             except IndexError as exc:
                 print(exc)
@@ -360,16 +358,14 @@ class Play(object):
             for app in self.currentSet:
                 details = self.details(app.get('docid'))
                 #print(details)
-                detailss = details.get('details')
-                appDetails = detailss.get('appDetails')
                 if details is None:
                     print('%s not available in Play Store' % app['docid'])
                     continue
                 details['filename'] = app.get('filename')
                 if self.debug:
                     print('Checking %s' % app['docid'])
-                    print('%d == %d ?' % (app['versionCode'], details['versionCode']))
-                if app['versionCode'] != details['versionCode']:
+                    print('%d == %d ?' % (app.get('details').get('appDetails')['versionCode'], details.get('details').get('appDetails')['versionCode']))
+                if app.get('details').get('appDetails')['versionCode'] !=  details.get('details').get('appDetails')['versionCode']:
                     toUpdate.append(details)
         return {'status': 'SUCCESS',
                 'message': toUpdate}

--- a/playmaker/static/app.module.js
+++ b/playmaker/static/app.module.js
@@ -159,13 +159,13 @@ app.component('appList', {
             }
           }
         }
-        if (a.images !== undefined) {
-          a.previewImage = a.images.filter(function(img) {
+        if (a.image !== undefined) {
+          a.previewImage = a.image.filter(function(img) {
             return img.imageType === 4;
           });
         }
-        if (a.installationSize !== undefined) {
-          a.formattedSize = a.installationSize / (1024*1024);
+        if (a.details.appDetails.installationSize !== undefined) {
+          a.formattedSize = a.details.appDetails.installationSize / (1024*1024);
           a.formattedSize = a.formattedSize.toFixed(2);
         }
         if (a.author === undefined) {

--- a/playmaker/static/app.module.js
+++ b/playmaker/static/app.module.js
@@ -243,7 +243,7 @@ app.component('searchView', {
           d.downloading = false;
           d.disabled = false;
         });
-        ctrl.results = data.message;
+        ctrl.results = data.message[0].child[0].child;
         ctrl.searching = false;
       });
     };

--- a/playmaker/static/app.module.js
+++ b/playmaker/static/app.module.js
@@ -67,12 +67,12 @@ app.component('appList', {
       app.updating = true;
       api.download(app, function(data) {
         if (data === 'err' || data.status === 'ERROR') {
-          global.addAlert('danger', 'Unable to update ' + app.docId);
+          global.addAlert('danger', 'Unable to update ' + app.docid);
           app.updating = false;
           return;
         }
         if (data.message.success.length === 0) {
-          global.addAlert('danger', 'Unable to update ' + app.docId);
+          global.addAlert('danger', 'Unable to update ' + app.docid);
           app.updating = false;
           return;
         }
@@ -96,7 +96,7 @@ app.component('appList', {
 
           data.message.forEach(function(newApp) {
             var oldAppIndex = ctrl.apps.findIndex(function(elem) {
-              return elem.docId === newApp.docId
+              return elem.docid === newApp.docid
             });
             if (oldAppIndex === -1) return;
             updateApp(ctrl.apps[oldAppIndex]);
@@ -107,14 +107,14 @@ app.component('appList', {
 
 
     ctrl.delete = function(app) {
-      api.remove(app.docId, function(data) {
+      api.remove(app.docid, function(data) {
         if (data.status === 'SUCCESS') {
           var i = ctrl.apps.findIndex(function(elem) {
-            return elem.docId === app.docId;
+            return elem.docid === app.docid;
           });
           ctrl.apps.splice(i, 1);
         } else {
-          global.addAlert('danger', 'Unable to delete ' + app.docId);
+          global.addAlert('danger', 'Unable to delete ' + app.docid);
         }
       });
     };
@@ -262,7 +262,7 @@ app.component('searchView', {
         if (data.status === 'SUCCESS') {
           if (data.message.success.length === 0) {
             app.downloading = false;
-            global.addAlert('warning', app.docId + ' can\'t be downloaded');
+            global.addAlert('warning', app.docid + ' can\'t be downloaded');
             return;
           }
         }

--- a/playmaker/static/app.service.js
+++ b/playmaker/static/app.service.js
@@ -79,11 +79,11 @@ angular.module('playmaker').service('api', ['$http', '$location', 'global', func
 
   this.download = function(app, callback) {
     var requestData = {
-      download: [app]
+      download: [app[0]]
     };
     $http({
       method: 'POST',
-      url: '/api/download',
+      url: '/api/',
       data: JSON.stringify(requestData)
     }).then(function success(response) {
         callback(response.data);

--- a/playmaker/static/app.service.js
+++ b/playmaker/static/app.service.js
@@ -79,11 +79,11 @@ angular.module('playmaker').service('api', ['$http', '$location', 'global', func
 
   this.download = function(app, callback) {
     var requestData = {
-      download: [app[0]]
+      download: [app]
     };
     $http({
       method: 'POST',
-      url: '/api/',
+      url: '/api/download',
       data: JSON.stringify(requestData)
     }).then(function success(response) {
         callback(response.data);

--- a/playmaker/views/app.html
+++ b/playmaker/views/app.html
@@ -34,9 +34,9 @@
               "val.full ? 'fas fa-star' : 'far fa-star'"
               aria-hidden="true"></i>
             <strong>{{app.formattedStars}}</strong><br>
-            <span><strong>Developer:</strong> {{app.author}}</span><br>
-            <span><strong>Version:</strong> {{app.versionCode}}</span><br>
-            <span><strong>Files:</strong> {{app.files.length}}</span><br>
+            <span><strong>Developer:</strong> {{app.creator}}</span><br>
+            <span><strong>Version:</strong> {{app.details.appDetails.versionCode}}</span><br>
+            <span><strong>Files:</strong> {{app.details.appDetails.file.length}}</span><br>
             <span ng-if="app.formattedSize !== undefined"><strong>Size:</strong> {{app.formattedSize}} MB</span>
             <span ng-if="app.formattedSize === undefined"><strong>Size:</strong> unknown</span><br>
             <span><strong>PackageId:</strong> {{app.docid}}</span><br>

--- a/playmaker/views/app.html
+++ b/playmaker/views/app.html
@@ -26,7 +26,7 @@
       <div class="panel panel-default">
         <div class="panel-body">
           <img ng-if="$ctrl.desktop" width="100" height="100" ng-src=
-          "{{app.previewImage[0].url}}">
+          "{{app.previewImage[0].imageUrl}}">
           <div class="apk-info">
             <strong><span class=
             "apk-item-title">{{app.title}}</span></strong>

--- a/playmaker/views/app.html
+++ b/playmaker/views/app.html
@@ -39,7 +39,7 @@
             <span><strong>Files:</strong> {{app.files.length}}</span><br>
             <span ng-if="app.formattedSize !== undefined"><strong>Size:</strong> {{app.formattedSize}} MB</span>
             <span ng-if="app.formattedSize === undefined"><strong>Size:</strong> unknown</span><br>
-            <span><strong>PackageId:</strong> {{app.docId}}</span><br>
+            <span><strong>PackageId:</strong> {{app.docid}}</span><br>
           </div>
         </div><!-- panel-body -->
         <div ng-hide="!app.updating" class="apk-progress">

--- a/playmaker/views/search.html
+++ b/playmaker/views/search.html
@@ -9,8 +9,7 @@
   </div>
   <div ng-hide="!$ctrl.searching" id="search-progress" class="progress">
     <div class="progress-bar progress-bar-striped active" role="progressbar"
-    aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style=
-    "width:100%">
+    aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width:100%">
       <span class="sr-only">Loading results</span>
     </div>
   </div><!-- progress -->
@@ -24,6 +23,7 @@
           <th>Id</th>
           <th>Version</th>
           <th>Size</th>
+          <th>Stars</th>
         </tr>
       </thead>
       <tbody id="table-body">
@@ -43,7 +43,8 @@
           <td>{{app.creator}}</td>
           <td>{{app.docid}}</td>
           <td>{{app.details.appDetails.versionCode}}</td>
-          <td>{{app.details.appDetails.file[0].size}}</td>
+          <td>{{ ((app.details.appDetails.file[0].size)/(1024*1024)).toFixed(2) }} MB</td>
+          <td>{{app.aggregateRating.starRating.toFixed(2)}} Stars</td>
         </tr>
       </tbody>
     </table>
@@ -56,8 +57,9 @@
       <div class="modal-body" id="modal-body">
         <strong>Id:</strong> {{app.docid}}<br>
         <strong>Developer:</strong> {{app.creator}}<br>
-        <strong>Size:</strong> {{app.details.appDetails.file[0].size}}<br>
-        <strong>Stars:</strong> {{app.aggregateRating.starRating}}
+        <strong>Version:</strong> {{app.details.appDetails.versionCode}}<br>
+        <strong>Size:</strong> {{ ((app.details.appDetails.file[0].size)/(1024*1024)).toFixed(2) }} MB<br>
+        <strong>Stars:</strong> {{app.aggregateRating.starRating.toFixed(2)}}
       </div>
       <div class="modal-footer">
         <button class="btn btn-default" type="button" ng-click="$close()">Close</button>

--- a/playmaker/views/search.html
+++ b/playmaker/views/search.html
@@ -40,10 +40,10 @@
             </a>
           </td>
           <td>{{app.title}}</td>
-          <td>{{app.author}}</td>
-          <td>{{app.docId}}</td>
-          <td>{{app.versionCode}}</td>
-          <td>{{app.files[0].size}}</td>
+          <td>{{app.creator}}</td>
+          <td>{{app.docid}}</td>
+          <td>{{app.details.appDetails.versionCode}}</td>
+          <td>{{app.details.appDetails.file[0].size}}</td>
         </tr>
       </tbody>
     </table>

--- a/playmaker/views/search.html
+++ b/playmaker/views/search.html
@@ -54,9 +54,9 @@
         <h3 class="modal-title" id="modal-title">{{app.title}}</h3>
       </div>
       <div class="modal-body" id="modal-body">
-        <strong>Id:</strong> {{app.docId}}<br>
-        <strong>Developer:</strong> {{app.author}}<br>
-        <strong>Size:</strong> {{app.files[0].size}}<br>
+        <strong>Id:</strong> {{app.docid}}<br>
+        <strong>Developer:</strong> {{app.creator}}<br>
+        <strong>Size:</strong> {{app.details.appDetails.file[0].size}}<br>
         <strong>Stars:</strong> {{app.aggregateRating.starRating}}
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
Hi, 
with #51 I saw, Playmaker was not possible to talk to Google Play Store any more. it seems there changed some API results in API v3. I'm really new to this API so I only made changes by guessing... 
If you're facing the same issues and need hotfix you are welcome to use this, but there will be not full functionality.

### Function of this Version
- [x] Search for APK
- [x] Download APK (few Apps fail to download, e.g. de.spiegel.android.app.spon)
- [x] Update fdroid repo
- [x] Delete APK from cache
- [x] Update applications cache
- [x] Show APK pictures
- [x] Show APK size in MB
- [ ] make ready for Python3.8